### PR TITLE
[CircleCI]masterブランチpush時にCloudRunへリビジョンをデプロイするが、リリースはしないよう修正

### DIFF
--- a/build/ci/config.yml
+++ b/build/ci/config.yml
@@ -165,14 +165,14 @@ jobs:
             - run:
                 name: "Deploy docker image to Cloud Run and release"
                 command: |
-                  gcloud run deploy api --image=${IMAGE_NAME} --project=${GCP_PJ_ID} --region=${GCP_REGION}
+                  gcloud run deploy api --image=${IMAGE_NAME} --project=${GCP_PJ_ID} --region=${GCP_REGION} --tag circleci-deploy
       - when:
             condition: << parameters.should_release >>
             steps:
                 - run:
                     name: "Deploy docker image to Cloud Run and release"
                     command: |
-                      gcloud run deploy api --image=${IMAGE_NAME} --project=${GCP_PJ_ID} --region=${GCP_REGION} --no-traffic
+                      gcloud run deploy api --image=${IMAGE_NAME} --project=${GCP_PJ_ID} --region=${GCP_REGION} --no-traffic --tag circleci-deploy
       - send-notification-with-slack:
           event: fail
           message: ":fire: CircleCI Job:${CIRCLE_JOB} failure ! :fire:"

--- a/build/ci/config.yml
+++ b/build/ci/config.yml
@@ -143,9 +143,13 @@ jobs:
           event: fail
           message: ":fire: CircleCI Job:${CIRCLE_JOB} (node${CIRCLE_NODE_INDEX}) failure ! :fire:"
 
-  build-image-and-deploy-and-release:
-    description: "Build Docker image and push it to Artifact Registry. After that, deploy to Cloud Run and release"
+  build-image-and-deploy:
+    description: "Build Docker image and push it to Artifact Registry. After that, deploy to Cloud Run. (After that, release it optionally)"
     executor: go
+    parameters:
+      should_release:
+        type: boolean
+        default: false
     steps:
       - checkout
       - install-ko
@@ -155,10 +159,20 @@ jobs:
           name: "Build Docker image and push to Artifact Registry"
           command: |
             echo "export IMAGE_NAME=$(KO_DOCKER_REPO=${GCP_REGION}-docker.pkg.dev/${GCP_PJ_ID}/api/sample_app ko build cmd/sample_app/main.go --bare)" >> $BASH_ENV
-      - run:
-          name: "Deploy to Cloud Run and release"
-          command: |
-            gcloud run deploy api --image=${IMAGE_NAME} --project=${GCP_PJ_ID} --region=${GCP_REGION}
+      - unless:
+          condition: << parameters.should_release >>
+          steps:
+            - run:
+                name: "Deploy docker image to Cloud Run and release"
+                command: |
+                  gcloud run deploy api --image=${IMAGE_NAME} --project=${GCP_PJ_ID} --region=${GCP_REGION}
+      - when:
+            condition: << parameters.should_release >>
+            steps:
+                - run:
+                    name: "Deploy docker image to Cloud Run and release"
+                    command: |
+                      gcloud run deploy api --image=${IMAGE_NAME} --project=${GCP_PJ_ID} --region=${GCP_REGION} --no-traffic
       - send-notification-with-slack:
           event: fail
           message: ":fire: CircleCI Job:${CIRCLE_JOB} failure ! :fire:"
@@ -180,7 +194,7 @@ workflows:
           workflow-name: "build-and-test"
           requires:
             - build-and-test
-  # masterブランチ用(デプロイまで行う)
+  # masterブランチ用(デプロイまで行うがリリースはしない)
   build-and-test-and-deploy:
     jobs:
       - send-notification-workflow-start:
@@ -192,10 +206,11 @@ workflows:
       - build-and-test:
           requires:
             - send-notification-workflow-start
-      - build-image-and-deploy-and-release:
+      - build-image-and-deploy:
+          should_release: false
           requires:
             - build-and-test
       - send-notification-workflow-success:
           workflow-name: "build-and-test-and-deploy"
           requires:
-            - build-image-and-deploy-and-release
+            - build-image-and-deploy


### PR DESCRIPTION
build-image-and-deploy-and-releaseジョブについて、
ジョブ名をbuild-image-and-deployに変更、パラメータとしてshould_releaseを追加してfalseの際に--no-trafficでcloud run deployコマンドを実行するよう修正。
また、masterブランチへのpush時にはshould_release: falseで実行するようworkflowを修正